### PR TITLE
Models

### DIFF
--- a/QmlNet/qml/NetAbstractItemModel.cpp
+++ b/QmlNet/qml/NetAbstractItemModel.cpp
@@ -1,3 +1,52 @@
 #include "NetAbstractItemModel.h"
 
 NetAbstractItemModel::NetAbstractItemModel() {}
+
+extern "C" {
+
+Creator(NetAbstractItemModel, abstract_item_model)
+Deleter(NetAbstractItemModel, abstract_item_model)
+
+void net_abstract_item_model_beginInsertColumns(NetNetAbstractItemModelContainer* container, ModelIdx parent, int first, int last) {
+    container->data->beginInsertColumns(parent, first, last);
+}
+SideEffecter(NetAbstractItemModel, abstract_item_model, endInsertColumns)
+
+void net_abstract_item_model_beginInsertRows(NetNetAbstractItemModelContainer* container, ModelIdx parent, int first, int last) {
+    container->data->beginInsertRows(parent, first, last);
+}
+SideEffecter(NetAbstractItemModel, abstract_item_model, endInsertRows)
+
+void net_abstract_item_model_beginMoveColumns(NetNetAbstractItemModelContainer* container, ModelIdx sourceParent, int sourceFirst, int sourceLast, ModelIdx destinationParent, int destinationChild) {
+    container->data->beginMoveColumns(sourceParent, sourceFirst, sourceLast, destinationParent, destinationChild);
+}
+SideEffecter(NetAbstractItemModel, abstract_item_model, endMoveColumns)
+
+void net_abstract_item_model_beginMoveRows(NetNetAbstractItemModelContainer* container, ModelIdx sourceParent, int sourceFirst, int sourceLast, ModelIdx destinationParent, int destinationChild) {
+    container->data->beginMoveRows(sourceParent, sourceFirst, sourceLast, destinationParent, destinationChild);
+}
+SideEffecter(NetAbstractItemModel, abstract_item_model, endMoveRows)
+
+void net_abstract_item_model_beginRemoveColumns(NetNetAbstractItemModelContainer* container, ModelIdx parent, int first, int last) {
+    container->data->beginRemoveColumns(parent, first, last);
+}
+SideEffecter(NetAbstractItemModel, abstract_item_model, endRemoveColumns)
+
+void net_abstract_item_model_beginRemoveRows(NetNetAbstractItemModelContainer* container, ModelIdx parent, int first, int last) {
+    container->data->beginRemoveRows(parent, first, last);
+}
+SideEffecter(NetAbstractItemModel, abstract_item_model, endRemoveRows)
+
+SideEffecter(NetAbstractItemModel, abstract_item_model, beginResetModel)
+SideEffecter(NetAbstractItemModel, abstract_item_model, endResetModel)
+
+SynthesizeGetSetter(NetAbstractItemModel, abstract_item_model, m_flags, flags, FlagsDelegate)
+SynthesizeGetSetter(NetAbstractItemModel, abstract_item_model, m_data, data, DataDelegate)
+SynthesizeGetSetter(NetAbstractItemModel, abstract_item_model, m_headerData, header_data, HeaderDataDelegate)
+SynthesizeGetSetter(NetAbstractItemModel, abstract_item_model, m_rowCount, row_count, RowCountDelegate)
+SynthesizeGetSetter(NetAbstractItemModel, abstract_item_model, m_columnCount, column_count, ColumnCountDelegate)
+SynthesizeGetSetter(NetAbstractItemModel, abstract_item_model, m_index, index, IndexDelegate)
+SynthesizeGetSetter(NetAbstractItemModel, abstract_item_model, m_parent, parent, ParentDelegate)
+SynthesizeGetSetter(NetAbstractItemModel, abstract_item_model, m_roleNames, role_names, RoleNamesDelegate)
+
+}

--- a/QmlNet/qml/NetAbstractItemModel.cpp
+++ b/QmlNet/qml/NetAbstractItemModel.cpp
@@ -1,0 +1,3 @@
+#include "NetAbstractItemModel.h"
+
+NetAbstractItemModel::NetAbstractItemModel() {}

--- a/QmlNet/qml/NetAbstractItemModel.h
+++ b/QmlNet/qml/NetAbstractItemModel.h
@@ -1,7 +1,10 @@
+#pragma once
+
 #include <QAbstractItemModel>
 #include "NetQModelIndex.h"
 #include "NetVariant.h"
 #include "NetUtil.h"
+#include "NetAbstractItemModelRoleNames.h"
 
 using ModelIdx = NetQModelIndexContainer*;
 using Variant = NetVariantContainer*;
@@ -27,6 +30,9 @@ using IndexDelegate = std::function<ModelIdx(int, int, ModelIdx)>;
 // IntPtr ParentDelegate( IntPtr )
 using ParentDelegate = std::function<ModelIdx(ModelIdx)>;
 
+// IntPtr RoleNamesDelegate()
+using RoleNamesDelegate = std::function<NetHashTypeContainer*(void)>;
+
 #define SynthesizeGetSetter(kind, name, delegate, delegateName, delKind) void net_ ## name ## _set_ ## delegateName(Net ## kind ## Container* container, delKind func) {\
     container->data->delegate = func;\
 }\
@@ -42,14 +48,14 @@ private:
 public:
     NetAbstractItemModel();
     FlagsDelegate m_flags = [=](ModelIdx idx) -> int {
-        return QAbstractItemModel::flags(*(idx->data.data()));
+        return QAbstractItemModel::flags(UnwrapVal(idx));
     };
     Qt::ItemFlags flags(const QModelIndex &idx) const override {
         return (Qt::ItemFlag) m_flags(wrap(idx));
     }
 
     DataDelegate m_data = [=](ModelIdx idx, int role) -> Variant {
-        return new NetVariantContainer{ NetVariant::fromQVariant(new QVariant(QAbstractItemModel::data(*(idx->data.data()), role)))};
+        return new NetVariantContainer{ NetVariant::fromQVariant(new QVariant(QAbstractItemModel::data(UnwrapVal(idx), role)))};
     };
     QVariant data(const QModelIndex &idx, int role = Qt::DisplayRole) const override {
         return m_data(wrap(idx), role)->variant->toQVariant();
@@ -63,14 +69,14 @@ public:
     }
 
     RowCountDelegate m_rowCount = [=](ModelIdx idx) -> int {
-        return QAbstractItemModel::rowCount(*(idx->data.data()));
+        return QAbstractItemModel::rowCount(UnwrapVal(idx));
     };
     int rowCount(const QModelIndex &parent = QModelIndex()) const override {
         return m_rowCount(wrap(parent));
     }
 
     ColumnCountDelegate m_columnCount = [=](ModelIdx idx) -> int {
-        return QAbstractItemModel::columnCount(*(idx->data.data()));
+        return QAbstractItemModel::columnCount(UnwrapVal(idx));
     };
     int columnCount(const QModelIndex &parent = QModelIndex()) const override {
         return m_columnCount(wrap(parent));
@@ -80,30 +86,55 @@ public:
         return new NetQModelIndexContainer{ QSharedPointer<QModelIndex>(new QModelIndex(createIndex(row, column))) };
     };
     QModelIndex index(int row, int column, const QModelIndex& parent) const override {
-        return *(m_index(row, column, wrap(parent))->data.data());
+        return UnwrapVal(m_index(row, column, wrap(parent)));
     }
 
     ParentDelegate m_parent = [=](ModelIdx idx) -> ModelIdx {
         return new NetQModelIndexContainer{ QSharedPointer<QModelIndex>(new QModelIndex()) };
     };
     QModelIndex parent(const QModelIndex& idx) const override {
-        return *(m_parent(wrap(idx))->data.data());
+        return UnwrapVal(m_parent(wrap(idx)));
     }
+
+    RoleNamesDelegate m_roleNames = [=]() -> Hash {
+        return new NetHashTypeContainer{ QSharedPointer<QHash<int,QByteArray>>( new QHash<int,QByteArray>(QAbstractItemModel::roleNames()) ) };
+    };
+    QHash<int,QByteArray> roleNames() const override {
+        return UnwrapVal(m_roleNames());
+    }
+
+    Publicizer(QAbstractItemModel, beginResetModel)
+    Publicizer(QAbstractItemModel, endResetModel)
+
+    void beginInsertColumns(ModelIdx parent, int first, int last) {
+        QAbstractItemModel::beginInsertColumns(UnwrapVal(parent), first, last);
+    }
+    Publicizer(QAbstractItemModel, endInsertColumns)
+
+    void beginInsertRows(ModelIdx parent, int first, int last) {
+        QAbstractItemModel::beginInsertRows(UnwrapVal(parent), first, last);
+    }
+    Publicizer(QAbstractItemModel, endInsertRows)
+
+    void beginMoveColumns(ModelIdx sourceParent, int sourceFirst, int sourceLast, ModelIdx destinationParent, int destinationChild) {
+        QAbstractItemModel::beginMoveColumns(UnwrapVal(sourceParent), sourceFirst, sourceLast, UnwrapVal(destinationParent), destinationChild);
+    }
+    Publicizer(QAbstractItemModel, endMoveColumns)
+
+    void beginMoveRows(ModelIdx sourceParent, int sourceFirst, int sourceLast, ModelIdx destinationParent, int destinationChild) {
+        QAbstractItemModel::beginMoveRows(UnwrapVal(sourceParent), sourceFirst, sourceLast, UnwrapVal(destinationParent), destinationChild);
+    }
+    Publicizer(QAbstractItemModel, endMoveRows)
+
+    void beginRemoveColumns(ModelIdx parent, int first, int last) {
+        QAbstractItemModel::beginRemoveColumns(UnwrapVal(parent), first, last);
+    }
+    Publicizer(QAbstractItemModel, endRemoveColumns)
+
+    void beginRemoveRows(ModelIdx parent, int first, int last) {
+        QAbstractItemModel::beginRemoveRows(UnwrapVal(parent), first, last);
+    }
+    Publicizer(QAbstractItemModel, endRemoveRows)
 };
 
 Container(NetAbstractItemModel)
-
-extern "C" {
-
-Creator(NetAbstractItemModel, abstract_item_model)
-Deleter(NetAbstractItemModel, abstract_item_model)
-
-SynthesizeGetSetter(NetAbstractItemModel, abstract_item_model, m_flags, flags, FlagsDelegate)
-SynthesizeGetSetter(NetAbstractItemModel, abstract_item_model, m_data, data, DataDelegate)
-SynthesizeGetSetter(NetAbstractItemModel, abstract_item_model, m_headerData, header_data, HeaderDataDelegate)
-SynthesizeGetSetter(NetAbstractItemModel, abstract_item_model, m_rowCount, row_count, RowCountDelegate)
-SynthesizeGetSetter(NetAbstractItemModel, abstract_item_model, m_columnCount, column_count, ColumnCountDelegate)
-SynthesizeGetSetter(NetAbstractItemModel, abstract_item_model, m_index, index, IndexDelegate)
-SynthesizeGetSetter(NetAbstractItemModel, abstract_item_model, m_parent, parent, ParentDelegate)
-
-}

--- a/QmlNet/qml/NetAbstractItemModel.h
+++ b/QmlNet/qml/NetAbstractItemModel.h
@@ -1,0 +1,109 @@
+#include <QAbstractItemModel>
+#include "NetQModelIndex.h"
+#include "NetVariant.h"
+#include "NetUtil.h"
+
+using ModelIdx = NetQModelIndexContainer*;
+using Variant = NetVariantContainer*;
+
+// int FlagsDelegate( IntPtr )
+using FlagsDelegate = std::function<int(ModelIdx)>;
+
+// IntPtr DataDelegate( IntPtr, int )
+using DataDelegate = std::function<Variant(ModelIdx, int)>;
+
+// IntPtr HeaderDataDelegate( int, int, int )
+using HeaderDataDelegate = std::function<Variant(int, int, int)>;
+
+// int RowCountDelegate( IntPtr )
+using RowCountDelegate = std::function<int(ModelIdx)>;
+
+// int ColumnCountDelegate( IntPtr )
+using ColumnCountDelegate = RowCountDelegate;
+
+// IntPtr IndexDelegate( int, int, IntPtr )
+using IndexDelegate = std::function<ModelIdx(int, int, ModelIdx)>;
+
+// IntPtr ParentDelegate( IntPtr )
+using ParentDelegate = std::function<ModelIdx(ModelIdx)>;
+
+#define SynthesizeGetSetter(kind, name, delegate, delegateName, delKind) void net_ ## name ## _set_ ## delegateName(Net ## kind ## Container* container, delKind func) {\
+    container->data->delegate = func;\
+}\
+delKind net_ ## name ## _get_ ## delegateName(Net ## kind ## Container* container) {\
+    return container->data->delegate;\
+}
+
+class NetAbstractItemModel : public QAbstractItemModel
+{
+    Q_OBJECT
+private:
+    NetQModelIndexContainer* wrap(const QModelIndex& idx) const { return new NetQModelIndexContainer{ QSharedPointer<QModelIndex>(new QModelIndex(idx)) }; }
+public:
+    NetAbstractItemModel();
+    FlagsDelegate m_flags = [=](ModelIdx idx) -> int {
+        return QAbstractItemModel::flags(*(idx->data.data()));
+    };
+    Qt::ItemFlags flags(const QModelIndex &idx) const override {
+        return (Qt::ItemFlag) m_flags(wrap(idx));
+    }
+
+    DataDelegate m_data = [=](ModelIdx idx, int role) -> Variant {
+        return new NetVariantContainer{ NetVariant::fromQVariant(new QVariant(QAbstractItemModel::data(*(idx->data.data()), role)))};
+    };
+    QVariant data(const QModelIndex &idx, int role = Qt::DisplayRole) const override {
+        return m_data(wrap(idx), role)->variant->toQVariant();
+    }
+
+    HeaderDataDelegate m_headerData = [=](int section, int orientation, int role) -> Variant {
+        return new NetVariantContainer{ NetVariant::fromQVariant( new QVariant( QAbstractItemModel::headerData(section, (Qt::Orientation)orientation, role) ) )};
+    };
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override {
+        return m_headerData(section, orientation, role)->variant->toQVariant();
+    }
+
+    RowCountDelegate m_rowCount = [=](ModelIdx idx) -> int {
+        return QAbstractItemModel::rowCount(*(idx->data.data()));
+    };
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override {
+        return m_rowCount(wrap(parent));
+    }
+
+    ColumnCountDelegate m_columnCount = [=](ModelIdx idx) -> int {
+        return QAbstractItemModel::columnCount(*(idx->data.data()));
+    };
+    int columnCount(const QModelIndex &parent = QModelIndex()) const override {
+        return m_columnCount(wrap(parent));
+    }
+
+    IndexDelegate m_index = [=](int row, int column, ModelIdx idx) -> ModelIdx {
+        return new NetQModelIndexContainer{ QSharedPointer<QModelIndex>(new QModelIndex(createIndex(row, column))) };
+    };
+    QModelIndex index(int row, int column, const QModelIndex& parent) const override {
+        return *(m_index(row, column, wrap(parent))->data.data());
+    }
+
+    ParentDelegate m_parent = [=](ModelIdx idx) -> ModelIdx {
+        return new NetQModelIndexContainer{ QSharedPointer<QModelIndex>(new QModelIndex()) };
+    };
+    QModelIndex parent(const QModelIndex& idx) const override {
+        return *(m_parent(wrap(idx))->data.data());
+    }
+};
+
+Container(NetAbstractItemModel)
+
+extern "C" {
+
+Creator(NetAbstractItemModel, abstract_item_model)
+Deleter(NetAbstractItemModel, abstract_item_model)
+
+SynthesizeGetSetter(NetAbstractItemModel, abstract_item_model, m_flags, flags, FlagsDelegate)
+SynthesizeGetSetter(NetAbstractItemModel, abstract_item_model, m_data, data, DataDelegate)
+SynthesizeGetSetter(NetAbstractItemModel, abstract_item_model, m_headerData, header_data, HeaderDataDelegate)
+SynthesizeGetSetter(NetAbstractItemModel, abstract_item_model, m_rowCount, row_count, RowCountDelegate)
+SynthesizeGetSetter(NetAbstractItemModel, abstract_item_model, m_columnCount, column_count, ColumnCountDelegate)
+SynthesizeGetSetter(NetAbstractItemModel, abstract_item_model, m_index, index, IndexDelegate)
+SynthesizeGetSetter(NetAbstractItemModel, abstract_item_model, m_parent, parent, ParentDelegate)
+
+}

--- a/QmlNet/qml/NetAbstractItemModelRoleNames.cpp
+++ b/QmlNet/qml/NetAbstractItemModelRoleNames.cpp
@@ -1,0 +1,8 @@
+#include "NetAbstractItemModelRoleNames.h"
+
+Creator(HashType, qmodelhash)
+Deleter(HashType, qmodelhash)
+
+void net_qmodelhash_insert(Hash hash, int num, const char* data) {
+    hash->data->insert(num, QString::fromLocal8Bit(data).toLocal8Bit());
+}

--- a/QmlNet/qml/NetAbstractItemModelRoleNames.h
+++ b/QmlNet/qml/NetAbstractItemModelRoleNames.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <QByteArray>
+#include <QHash>
+#include <QSharedPointer>
+
+#include "NetUtil.h"
+
+#define HashType QHash<int,QByteArray>
+Container(HashType)
+
+using Hash = NetHashTypeContainer*;

--- a/QmlNet/qml/NetQMimeData.cpp
+++ b/QmlNet/qml/NetQMimeData.cpp
@@ -1,0 +1,28 @@
+#include "NetQMimeData.h"
+
+extern "C" {
+
+Deleter(QMimeData, qmimedata)
+SideEffecter(QMimeData, qmimedata, clear)
+// todo: QVariant colorData() const
+// todo: QByteArray data(const QString &mimeType) const
+// todo: virtual QStringList formats() const
+SimpleGetter(QMimeData, qmimedata, hasColor, bool)
+// todo: virtual bool hasFormat(const QString &mimeType) const
+SimpleGetter(QMimeData, qmimedata, hasHtml, bool)
+SimpleGetter(QMimeData, qmimedata, hasImage, bool)
+SimpleGetter(QMimeData, qmimedata, hasText, bool)
+SimpleGetter(QMimeData, qmimedata, hasUrls, bool)
+QStringGetter(QMimeData, qmimedata, html)
+// todo: QVariant imageData() const
+// todo: void removeFormat(const QString &mimeType)
+// todo: void setColorData(const QVariant &color)
+// todo: void setData(const QString &mimeType, const QByteArray &data)
+// todo: void setHtml(const QString &html)
+// todo: void setImageData(const QVariant &image)
+// todo: void setText(const QString &text)
+// todo: void setUrls(const QList<QUrl> &urls)
+QStringGetter(QMimeData, qmimedata, text)
+// todo: QList<QUrl> urls() const
+
+}

--- a/QmlNet/qml/NetQMimeData.h
+++ b/QmlNet/qml/NetQMimeData.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <QSharedPointer>
+#include <QMimeData>
+#include "NetUtil.h"
+
+Container(QMimeData)

--- a/QmlNet/qml/NetQModelIndex.cpp
+++ b/QmlNet/qml/NetQModelIndex.cpp
@@ -4,6 +4,7 @@
 
 extern "C" {
 
+Creator(QModelIndex, qmodelindex)
 Deleter(QModelIndex, qmodelindex)
 
 SimpleGetter(QModelIndex, qmodelindex, column, int)

--- a/QmlNet/qml/NetQModelIndex.cpp
+++ b/QmlNet/qml/NetQModelIndex.cpp
@@ -1,0 +1,13 @@
+#include <QModelIndex>
+
+#include "NetQModelIndex.h"
+
+extern "C" {
+
+Deleter(QModelIndex, qmodelindex)
+
+SimpleGetter(QModelIndex, qmodelindex, column, int)
+SimpleGetter(QModelIndex, qmodelindex, row, int)
+WrappedGetter(QModelIndex, qmodelindex, parent, QModelIndex)
+
+}

--- a/QmlNet/qml/NetQModelIndex.h
+++ b/QmlNet/qml/NetQModelIndex.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <QSharedPointer>
+#include <QModelIndex>
+#include "NetUtil.h"
+
+Container(QModelIndex)

--- a/QmlNet/qml/NetUtil.h
+++ b/QmlNet/qml/NetUtil.h
@@ -1,0 +1,25 @@
+#define Container(kind) struct Net ## kind ## Container {\
+    QSharedPointer<kind> data;\
+};
+#define SideEffecter(kind, name, function) Q_DECL_EXPORT void net_ ## name ## _ ## function (Net ## kind ## Container* container) {\
+    container->data->function();\
+}
+#define SimpleGetter(kind, name, property, ret) Q_DECL_EXPORT ret net_ ## name ## _ ## property (Net ## kind ## Container* container) {\
+    return container->data->property();\
+}
+#define Creator(kind, name) Q_DECL_EXPORT Net ## kind ## Container* net_ ## name ## _create() {\
+    return new Net ## kind ## Container{\
+        .data = QSharedPointer<kind>(new kind)\
+    };\
+}
+#define Deleter(kind, name) Q_DECL_EXPORT void net_ ## name ## _destroy (Net ## kind ## Container* container) {\
+    delete container;\
+}
+#define WrappedGetter(kind, name, property, returnKind) Q_DECL_EXPORT Net ## returnKind ## Container* net_ ## name ## _ ## property (Net ## kind ## Container* container){\
+    return new Net ## returnKind ## Container {\
+        .data = QSharedPointer<returnKind>(new returnKind(container->data->property()))\
+    };\
+}
+#define QStringGetter(kind, name, property) Q_DECL_EXPORT const char* net_ ## name ## _ ## property (Net ## kind ## Container* container) {\
+    return container->data->property().toUtf8().constData();\
+};

--- a/QmlNet/qml/NetUtil.h
+++ b/QmlNet/qml/NetUtil.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #define Container(kind) struct Net ## kind ## Container {\
     QSharedPointer<kind> data;\
 };
@@ -23,3 +25,9 @@
 #define QStringGetter(kind, name, property) Q_DECL_EXPORT const char* net_ ## name ## _ ## property (Net ## kind ## Container* container) {\
     return container->data->property().toUtf8().constData();\
 };
+#define Publicizer(superclass, function) void function() {\
+    superclass::function();\
+}
+
+#define UnwrapVal(in) *(in->data.data())
+#define UnwrapObj(in) in->data.data()

--- a/QmlNet/qml/qml.pri
+++ b/QmlNet/qml/qml.pri
@@ -21,6 +21,7 @@ HEADERS += \
     $$PWD/NetQObjectArg.h \
     $$PWD/NetQModelIndex.h \
     $$PWD/NetAbstractItemModel.h \
+    $$PWD/NetAbstractItemModelRoleNames.h \
     $$PWD/QLocaleInterop.h
 
 SOURCES += \
@@ -46,4 +47,5 @@ SOURCES += \
     $$PWD/NetQObjectArg.cpp \
     $$PWD/NetQModelIndex.cpp \
     $$PWD/NetAbstractItemModel.cpp \
+    $$PWD/NetAbstractItemModelRoleNames.cpp \
     $$PWD/QLocaleInterop.cpp

--- a/QmlNet/qml/qml.pri
+++ b/QmlNet/qml/qml.pri
@@ -19,6 +19,8 @@ HEADERS += \
     $$PWD/NetQObject.h \
     $$PWD/NetQObjectSignalConnection.h \
     $$PWD/NetQObjectArg.h \
+    $$PWD/NetQModelIndex.h \
+    $$PWD/NetAbstractItemModel.h \
     $$PWD/QLocaleInterop.h
 
 SOURCES += \
@@ -42,4 +44,6 @@ SOURCES += \
     $$PWD/NetQObject.cpp \
     $$PWD/NetQObjectSignalConnection.cpp \
     $$PWD/NetQObjectArg.cpp \
+    $$PWD/NetQModelIndex.cpp \
+    $$PWD/NetAbstractItemModel.cpp \
     $$PWD/QLocaleInterop.cpp


### PR DESCRIPTION
This PR implements the C glue to implement the minimum recommended APIs necessary to implement read-only models in C# that can interop with QML, handling 90% of usecases for models.